### PR TITLE
Commit auto-snapshots to GitHub repo via Contents API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 # Operating system files
 .DS_Store
 Thumbs.db
+
+# Streamlit secrets (never commit the real token)
+.streamlit/secrets.toml

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,12 @@
+# Copy this file to .streamlit/secrets.toml for local development,
+# or paste the keys into the Streamlit Cloud secrets manager.
+#
+# GITHUB_TOKEN must be a fine-grained personal access token with
+# "Contents: Read and write" permission on this repository.
+#
+# GITHUB_REPO and GITHUB_BRANCH are optional; the defaults shown below
+# match this project.
+
+GITHUB_TOKEN  = "github_pat_XXXXXXXXXXXXXXXXXXXX"
+GITHUB_REPO   = "jcabot/oss-lowcode-tools"   # optional
+GITHUB_BRANCH = "main"                        # optional

--- a/app.py
+++ b/app.py
@@ -129,12 +129,31 @@ excluded_repos = {
 # Filter out excluded repositories
 st.session_state.repos = [repo for repo in st.session_state.repos if repo['name'] not in excluded_repos]
 
-# Auto-snapshot: persist the current live list when no recent snapshot exists
+# Auto-snapshot: persist the current live list when no recent snapshot exists.
+# If a GITHUB_TOKEN secret is configured the snapshot is also committed to the
+# repo so it survives Streamlit Cloud restarts (ephemeral filesystem).
 if st.session_state.get('api_succeeded') and not st.session_state.get('snapshot_taken'):
     saved_path = snapshot_utils.auto_snapshot(st.session_state.repos)
     st.session_state.snapshot_taken = True
     if saved_path:
-        st.success(f"New snapshot saved: {saved_path}")
+        filename = os.path.basename(saved_path)
+        try:
+            gh_token = st.secrets.get("GITHUB_TOKEN")
+        except Exception:
+            gh_token = None
+
+        if gh_token:
+            gh_repo   = st.secrets.get("GITHUB_REPO",   "jcabot/oss-lowcode-tools")
+            gh_branch = st.secrets.get("GITHUB_BRANCH", "main")
+            ok = snapshot_utils.commit_snapshot_to_github(
+                saved_path, gh_token, gh_repo, gh_branch
+            )
+            if ok:
+                st.success(f"New snapshot committed to the repository: snapshots/{filename}")
+            else:
+                st.warning(f"Snapshot saved locally but could not be committed to GitHub: {filename}")
+        else:
+            st.success(f"New snapshot saved locally: {filename}")
 
 repos = st.session_state.repos
 

--- a/snapshot_utils.py
+++ b/snapshot_utils.py
@@ -6,8 +6,10 @@ Snapshot files live in snapshots/ and are named snapshot-YYYY-MM-DD.csv.
 
 from __future__ import annotations
 
+import base64
 import os
 import re
+import requests
 import pandas as pd
 from datetime import datetime, timedelta
 
@@ -74,3 +76,42 @@ def auto_snapshot(repos: list[dict]) -> str | None:
         return None  # already taken today
     repos_to_csv(repos, path)
     return path
+
+
+def commit_snapshot_to_github(
+    local_path: str,
+    token: str,
+    repo: str = "jcabot/oss-lowcode-tools",
+    branch: str = "main",
+) -> bool:
+    """Commit the snapshot CSV at *local_path* to GitHub via the Contents API.
+
+    Uses a personal access token with 'contents: write' permission.
+    Returns True on success, False otherwise.
+    """
+    filename = os.path.basename(local_path)
+    repo_path = f"snapshots/{filename}"
+    url = f"https://api.github.com/repos/{repo}/contents/{repo_path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    with open(local_path, "rb") as f:
+        content_b64 = base64.b64encode(f.read()).decode("ascii")
+
+    # Fetch existing SHA if the file already exists (required for updates)
+    existing = requests.get(url, headers=headers, params={"ref": branch})
+    sha = existing.json().get("sha") if existing.status_code == 200 else None
+
+    payload: dict = {
+        "message": f"Add snapshot {filename}",
+        "content": content_b64,
+        "branch": branch,
+    }
+    if sha:
+        payload["sha"] = sha
+
+    response = requests.put(url, headers=headers, json=payload)
+    return response.status_code in (200, 201)


### PR DESCRIPTION
When a new snapshot is created and GITHUB_TOKEN is set in Streamlit secrets, the CSV is committed back to the repo so it persists across Streamlit Cloud restarts. Add secrets.toml.example documenting the required token and optional GITHUB_REPO/GITHUB_BRANCH overrides. Gitignore secrets.toml.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds GitHub write-back using a PAT from Streamlit secrets, which introduces new network/API failure modes and requires careful secret handling to avoid accidental token exposure or unexpected commits.
> 
> **Overview**
> When an auto-snapshot CSV is created, the app now optionally commits it back into `snapshots/` on GitHub using the Contents API if `GITHUB_TOKEN` is present in Streamlit secrets, making snapshots survive Streamlit Cloud restarts.
> 
> This introduces a new `snapshot_utils.commit_snapshot_to_github()` helper (base64 upload, optional update via SHA) and adds a `.streamlit/secrets.toml.example` plus a `.gitignore` rule to prevent committing real secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a91aaad323447f8943024036b61cc068f090596e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->